### PR TITLE
Remove required attribute for fields

### DIFF
--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -98,7 +98,7 @@ module Oat
             data[:class] << value
           end
 
-          %w(category required type value title).each do |attribute|
+          %w(category type value title).each do |attribute|
             define_method(attribute) do |value|
               data[attribute.to_sym] = value
             end


### PR DESCRIPTION
Required is moved to a class on the frontend side.
See: https://github.com/evopark/product-backend/pull/20