### PR TITLE
Remove uniqueness for entities

### DIFF
--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -46,9 +46,7 @@ module Oat
           ent.rel(name)
           ent_hash = ent.to_hash
 
-          unless data[:entities].include? ent_hash
-            data[:entities] << ent_hash
-          end
+          data[:entities] << ent_hash
         end
       end
 


### PR DESCRIPTION
When adding multiple entities with the same
attributes the Siren-Adapter just ignored the new
entity if there was already one with the same
values.